### PR TITLE
Replaces os.system with subprocess.Popen

### DIFF
--- a/docs/CHANGELOG/index.html
+++ b/docs/CHANGELOG/index.html
@@ -379,6 +379,7 @@
 <p><strong>Changes</strong>:</p>
 <ul>
 <li>Adds <code>use_unique_id</code> option when creating a Job object. This will then create a separate error, log, and output file for each of the arguments in the Job <code>args</code> list.</li>
+<li>Replaces all occurances of <code>os.system()</code> with <code>subprocess.Popen()</code>. This won't affect anything the user touches, just modernizing under-the-hood stuff. </li>
 </ul>
 <h2 id="version-010">Version 0.1.0<a class="headerlink" href="#version-010" title="Permanent link">&para;</a></h2>
 <p><strong>Changes</strong>:</p>

--- a/docs/mkdocs/search_index.json
+++ b/docs/mkdocs/search_index.json
@@ -117,7 +117,7 @@
         }, 
         {
             "location": "/CHANGELOG/", 
-            "text": "Release Notes\n\n\nVersion 0.1.1\n\n\nChanges\n:\n\n\n\n\nAdds \nuse_unique_id\n option when creating a Job object. This will then create a separate error, log, and output file for each of the arguments in the Job \nargs\n list.\n\n\n\n\nVersion 0.1.0\n\n\nChanges\n:\n\n\n\n\nAdds \nrequest_cpus\n attribute to Job object to make it easier to request a specified number of CPUs.\n\n\nAdds \npycondor.get_queue()\n feature to get \ncondor_q\n information.\n\n\nJob and Dagman object methods now return \nself\n.\n\n\nFixed typo in logger formatting.", 
+            "text": "Release Notes\n\n\nVersion 0.1.1\n\n\nChanges\n:\n\n\n\n\nAdds \nuse_unique_id\n option when creating a Job object. This will then create a separate error, log, and output file for each of the arguments in the Job \nargs\n list.\n\n\nReplaces all occurances of \nos.system()\n with \nsubprocess.Popen()\n. This won't affect anything the user touches, just modernizing under-the-hood stuff. \n\n\n\n\nVersion 0.1.0\n\n\nChanges\n:\n\n\n\n\nAdds \nrequest_cpus\n attribute to Job object to make it easier to request a specified number of CPUs.\n\n\nAdds \npycondor.get_queue()\n feature to get \ncondor_q\n information.\n\n\nJob and Dagman object methods now return \nself\n.\n\n\nFixed typo in logger formatting.", 
             "title": "Release notes"
         }, 
         {
@@ -127,7 +127,7 @@
         }, 
         {
             "location": "/CHANGELOG/#version-011", 
-            "text": "Changes :   Adds  use_unique_id  option when creating a Job object. This will then create a separate error, log, and output file for each of the arguments in the Job  args  list.", 
+            "text": "Changes :   Adds  use_unique_id  option when creating a Job object. This will then create a separate error, log, and output file for each of the arguments in the Job  args  list.  Replaces all occurances of  os.system()  with  subprocess.Popen() . This won't affect anything the user touches, just modernizing under-the-hood stuff.", 
             "title": "Version 0.1.1"
         }, 
         {

--- a/mkdocs/docs/CHANGELOG.md
+++ b/mkdocs/docs/CHANGELOG.md
@@ -5,6 +5,7 @@
 **Changes**:
 
 * Adds `use_unique_id` option when creating a Job object. This will then create a separate error, log, and output file for each of the arguments in the Job `args` list.
+* Replaces all occurances of `os.system()` with `subprocess.Popen()`. This won't affect anything the user touches, just modernizing under-the-hood stuff. 
 
 
 ## Version 0.1.0

--- a/pycondor/pycondor.py
+++ b/pycondor/pycondor.py
@@ -2,6 +2,7 @@
 import os
 import glob
 import time
+import subprocess
 
 from . import base
 from . import logger
@@ -265,10 +266,13 @@ class Job(BaseSubmitNode):
             message = 'You are submitting a Job with {} arguments. Consider using a Dagman in the future to help monitor jobs.'.format(len(self.args))
             self.logger.warning(message)
 
+        # Construct and execute condor_submit command
         command = 'condor_submit {}'.format(self.submit_file)
         for option in kwargs:
             command += ' {} {}'.format(option, kwargs[option])
-        os.system(command)
+        proc = subprocess.Popen([command], stdout=subprocess.PIPE, shell=True)
+        out, err = proc.communicate()
+        print(out)
 
         return
 
@@ -362,11 +366,14 @@ class Dagman(BaseSubmitNode):
         return self
 
     def submit_dag(self, maxjobs=3000, **kwargs):
+        # Construct and execute condor_submit_dag command
         command = 'condor_submit_dag -maxjobs {} {}'.format(
             maxjobs, self.submit_file)
         for option in kwargs:
             command += ' {} {}'.format(option, kwargs[option])
-        os.system(command)
+        proc = subprocess.Popen([command], stdout=subprocess.PIPE, shell=True)
+        out, err = proc.communicate()
+        print(out)
 
         return
 


### PR DESCRIPTION
All occurances of os.system have been replaced with the more standard
subprocess.Popen. The documentation was updated (and re-built)
accordingly. See issue #16 