### PR TITLE
Adds retry option to Job object

### DIFF
--- a/docs/docs/CHANGELOG.md
+++ b/docs/docs/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Release Notes
 
+## Version 0.1.2
+
+**Changes**:
+
+* Adds `retry` option when creating a Job object. This allows the user to
+specify the number of times failed nodes in the Job should be re-submitted.
+
+
 ## Version 0.1.1
 
 **Changes**:

--- a/docs/docs/Dagman.md
+++ b/docs/docs/Dagman.md
@@ -1,5 +1,5 @@
 
-```
+```python
 Dagman(name, submit=cwd, extra_lines=None, verbose=0)
 ```
 

--- a/docs/docs/Job.md
+++ b/docs/docs/Job.md
@@ -1,9 +1,9 @@
 
-```
+```python
 Job(name, executable, error=None, log=None, output=None, submit=cwd,
     request_memory=None, request_disk=None, request_cpus=None, getenv=True,
     universe='vanilla', initialdir=None, notification='never', requirements=None,
-    queue=None, extra_lines=None, use_unique_id=False, verbose=0)
+    queue=None, extra_lines=None, retry=None, use_unique_id=False, verbose=0)
 ```
 
 The `Job` object consists of an executable to run on Condor, any specifications to include in the corresponding submit file (e.g. memory request, universe execution environment, etc.), and any arguments that you would like to pass to the executable. `Job` objects can be submitted directly to HTCondor, or can be included in a `Dagman` object for additional job management functionality.
@@ -76,6 +76,14 @@ The `Job` object consists of an executable to run on Condor, any specifications 
 * `extra_lines` : `list` (default: `None`)
 
     List of additional lines to be added to submit file.
+
+* `retry` : `int` (default: `None`)
+
+    *(Added in version 0.1.2)*
+
+    Option to specify the number of times to retry failed nodes for this Job.
+    Default number of retries is 0. *Note*: this feature is only available to
+    Jobs that are submitted via a Dagman.
 
 * `use_unique_id` : `bool` (default: `False`)
 


### PR DESCRIPTION
Adds retry option to Job object to allow for re-submission of failed nodes when a Job is submitted from a Dagman. See issue #23 