### PR TITLE
Fixes submit file vs. log/error/out file name mismatch

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -16,6 +16,7 @@ Version 0.1.5 (TBD)
 **Bug Fixes**:
 
 * Fixed bug where the queue parameter for a Job was not written to the job submit file when the Job was built by a Dagman. (See `PR #42 <https://github.com/jrbourbeau/pycondor/pull/42>`_)
+* Fixed bug that caused a filename mismatch between a ``Job`` submit file and the error/log/output files when a named argument is added to a ``Job``, and the ``Job`` is built with ``fancyname=True``. (See `PR #45 <https://github.com/jrbourbeau/pycondor/pull/48>`_)
 
 
 Version 0.1.4 (2017-06-08)

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -298,6 +298,7 @@ class Job(BaseNode):
 
         # Add submit_file data member to job for later use
         self.submit_file = submit_file
+        self.submit_name = name
 
         return
 

--- a/pycondor/tests/test_dagman.py
+++ b/pycondor/tests/test_dagman.py
@@ -19,9 +19,7 @@ def test_job_dag_submit_file_same(tmpdir):
     # same whether built from a Dagman or not. See issue #38.
 
     example_script = os.path.join('examples/savelist.py')
-
     submit_dir = str(tmpdir.mkdir('submit'))
-
     # Build Job object that will be built outside of a Dagman
     job_outside_dag = pycondor.Job('job_outside_dag', example_script,
                                    submit=submit_dir, queue=5)
@@ -37,3 +35,33 @@ def test_job_dag_submit_file_same(tmpdir):
     # Check that the contents of the two Job submit files are the same
     assert filecmp.cmp(job_outside_dag.submit_file, job_inside_dag.submit_file,
                        shallow=False)
+
+
+def test_job_arg_name_files(tmpdir):
+    # Test to check that when a named argument is added to a Job, and the Job
+    # is built with fancyname=True, the Job submit file and the
+    # error/log/output files for the argument start with the same index.
+    # E.g. job_(date)_01.submit, job_(date)_01.error, etc.
+    # Regression test for issue #47
+    example_script = os.path.join('examples/savelist.py')
+    submit_dir = str(tmpdir.mkdir('submit'))
+
+    job = pycondor.Job('testjob', example_script, submit=submit_dir)
+    job.add_arg('arg', name='argname')
+    dagman = pycondor.Dagman('testdagman', submit=submit_dir)
+    dagman.add_job(job)
+    dagman.build(fancyname=True)
+
+    with open(dagman.submit_file, 'r') as dagman_submit_file:
+        dagman_submit_lines = dagman_submit_file.readlines()
+
+    # Get root of the dagman submit file (submit file basename without .submit)
+    submit_file_line = dagman_submit_lines[0]
+    submit_file_basename = submit_file_line.split('/')[-1].rstrip()
+    submit_file_root = os.path.splitext(submit_file_basename)[0]
+    # Get job_name variable (used to built error/log/output file basenames)
+    jobname_line = dagman_submit_lines[2]
+    jobname = jobname_line.split('"')[-2]
+    other_file_root = '_'.join(jobname.split('_')[:-1])
+
+    assert submit_file_root == other_file_root


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/jrbourbeau/pycondor/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->

Fixes #47

#### What does this pull request implement/fix? Explain your changes.

This PR fixes a bug causing a name mismatch between the submit file and error/log/output files for Jobs that have argument names and are submitted from a Dagman. The name mismatch happens when `fancyname=True`, the corresponding job number starts at 1 for submit files, while the job index starts at 2 for all other files. For example, 

```python
# index starts at 1
examplejob_01.submit
# index starts at 2
examplejob_02.output
examplejob_02.error
examplejob_02.log
```
