### PR TITLE
Fix progbar rounding

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -18,6 +18,7 @@ Version 0.1.5 (TBD)
 
 * Fixed bug where the queue parameter for a Job was not written to the job submit file when the Job was built by a Dagman. (See `PR #42 <https://github.com/jrbourbeau/pycondor/pull/42>`_)
 * Fixed bug that caused a filename mismatch between a ``Job`` submit file and the error/log/output files when a named argument is added to a Job, and the Job is built with ``fancyname=True``. (See `PR #48 <https://github.com/jrbourbeau/pycondor/pull/48>`_)
+* Fixed issue that caused ``dagman_progress`` to round up the percentage of jobs that were marked as done. (See `PR #52 <https://github.com/jrbourbeau/pycondor/pull/52>`_)
 
 
 Version 0.1.4 (2017-06-08)

--- a/pycondor/command_line.py
+++ b/pycondor/command_line.py
@@ -110,9 +110,8 @@ def progress_bar_str(status, datetime_start, datetime_current, length=30,
         frac_done = 0
     width = int(frac_done * length)
 
-    bar_str = '\r[{0:<{1}}] {2:0.0%} Done'.format(prog_char*width,
-                                                  length,
-                                                  frac_done)
+    bar_str = '\r[{0:<{1}}] {2}% Done'.format(prog_char*width, length,
+                                              int(100*frac_done))
     count_str = '{} done, {} queued, {} ready, {} unready, {} failed'.format(
             status.Done, status.Queued, status.Ready,
             status.UnReady, status.Failed)

--- a/pycondor/tests/test_command_line.py
+++ b/pycondor/tests/test_command_line.py
@@ -1,7 +1,8 @@
 
 import pytest
 from datetime import datetime
-from pycondor.command_line import line_to_datetime, progress_bar_str
+from pycondor.command_line import (line_to_datetime, progress_bar_str,
+                                   Status, _states)
 
 
 def test_line_to_datetime():
@@ -17,3 +18,19 @@ def test_progress_bar_str_type_fail():
         progress_bar_str('not-a-status-object', datetime.now(), datetime.now())
     error = 'status must be of type Status'
     assert error == str(excinfo.value)
+
+
+def test_progress_bar():
+    # Test to check the output of progress_bar_str
+
+    # Create status that is 99.5% done (want to make sure this is displayed
+    # as 99% done, not 100% done).
+    jobs = [0]*len(_states)
+    jobs[0], jobs[2] = 199, 1
+    status = Status(*jobs)
+    prog_bar_str = progress_bar_str(status, datetime.now(), datetime.now(),
+                                    length=30, prog_char='#')
+
+    test_str = '\r[############################# ] 99% Done | 199 done, ' + \
+               '1 queued, 0 ready, 0 unready, 0 failed | 0.0m'
+    assert prog_bar_str == test_str

--- a/pycondor/tests/test_command_line.py
+++ b/pycondor/tests/test_command_line.py
@@ -23,8 +23,8 @@ def test_progress_bar_str_type_fail():
 def test_progress_bar():
     # Test to check the output of progress_bar_str
 
-    # Create status that is 99.5% done (want to make sure this is displayed
-    # as 99% done, not 100% done).
+    # Create status that is 99.5% done. Want to make sure this is displayed
+    # as 99% done, not 100% done. See issue #51.
     jobs = [0]*len(_states)
     jobs[0], jobs[2] = 199, 1
     status = Status(*jobs)


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/jrbourbeau/pycondor/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->

Fixes #51 

#### What does this pull request implement/fix? Explain your changes.

Rounds down the percentage of jobs done outputted from `dagman_progress` to avoid prematurely displaying `100% Done` while there are still jobs that are yet to complete.  

