### PR TITLE
Updates Dagman build method to use argument names, if provided

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -19,6 +19,7 @@ Version 0.1.5 (TBD)
 * Fixed bug where the queue parameter for a Job was not written to the job submit file when the Job was built by a Dagman. (See `PR #42 <https://github.com/jrbourbeau/pycondor/pull/42>`_)
 * Fixed bug that caused a filename mismatch between a ``Job`` submit file and the error/log/output files when a named argument is added to a Job, and the Job is built with ``fancyname=True``. (See `PR #48 <https://github.com/jrbourbeau/pycondor/pull/48>`_)
 * Fixed issue that caused ``dagman_progress`` to round up the percentage of jobs that were marked as done. (See `PR #52 <https://github.com/jrbourbeau/pycondor/pull/52>`_)
+* Fixed the Dagman submit file build procedure to include the name of Job named arguments in the Dagman node name (See `PR #53 <https://github.com/jrbourbeau/pycondor/pull/53>`_)
 
 
 Version 0.1.4 (2017-06-08)

--- a/pycondor/tests/test_dagman.py
+++ b/pycondor/tests/test_dagman.py
@@ -2,15 +2,16 @@
 import os
 import filecmp
 import pytest
-import pycondor
-from .utils import clear_pycondor_environment_variables
+from pycondor import Job, Dagman
+from pycondor.dagman import _iter_job_args
+from pycondor.tests.utils import clear_pycondor_environment_variables
 
 clear_pycondor_environment_variables()
 
 
 def test_add_job_int_fail():
     with pytest.raises(TypeError) as excinfo:
-        dag = pycondor.Dagman('dagname')
+        dag = Dagman('dagname')
         dag.add_job(50)
     error = 'Expecting a Job or Dagman. ' + \
             'Got an object of type {}'.format(type(50))
@@ -24,14 +25,14 @@ def test_job_dag_submit_file_same(tmpdir):
     example_script = os.path.join('examples/savelist.py')
     submit_dir = str(tmpdir.mkdir('submit'))
     # Build Job object that will be built outside of a Dagman
-    job_outside_dag = pycondor.Job('test_job', example_script,
-                                   submit=submit_dir, queue=5)
+    job_outside_dag = Job('test_job', example_script, submit=submit_dir,
+                          queue=5)
     job_outside_dag.build(fancyname=False)
 
     # Build Job object that will be built inside of a Dagman
-    job_inside_dag = pycondor.Job('test_job', example_script,
-                                  submit=submit_dir, queue=5)
-    dagman = pycondor.Dagman('exampledagman', submit=submit_dir)
+    job_inside_dag = Job('test_job', example_script, submit=submit_dir,
+                         queue=5)
+    dagman = Dagman('exampledagman', submit=submit_dir)
     dagman.add_job(job_inside_dag)
     dagman.build(fancyname=False)
 
@@ -50,9 +51,9 @@ def test_job_arg_name_files(tmpdir):
     submit_dir = str(tmpdir.mkdir('submit'))
 
     for fancyname in [True, False]:
-        job = pycondor.Job('testjob', example_script, submit=submit_dir)
+        job = Job('testjob', example_script, submit=submit_dir)
         job.add_arg('arg', name='argname')
-        dagman = pycondor.Dagman('testdagman', submit=submit_dir)
+        dagman = Dagman('testdagman', submit=submit_dir)
         dagman.add_job(job)
         dagman.build(fancyname=fancyname)
 
@@ -69,3 +70,32 @@ def test_job_arg_name_files(tmpdir):
         other_file_root = '_'.join(jobname.split('_')[:-1])
 
         assert submit_file_root == other_file_root
+
+
+def test_iter_job_args(tmpdir):
+    # Check node names yielded by _iter_job_args
+    example_script = os.path.join('examples/savelist.py')
+    submit_dir = str(tmpdir.mkdir('submit'))
+
+    job = Job('testjob', example_script, submit=submit_dir)
+    job.add_arg('argument1', name='arg1')
+    job.add_arg('argument2')
+    job.build()
+    for idx, (node_name, jobarg) in enumerate(_iter_job_args(job)):
+        if jobarg.name is not None:
+            assert node_name == '{}_{}'.format(job.submit_name, jobarg.name)
+        else:
+            assert node_name == '{}_arg_{}'.format(job.submit_name, idx)
+
+
+def test_iter_job_args_raises(tmpdir):
+    # Check _iter_job_args raises a StopIteration exception on a Job w/o args
+    example_script = os.path.join('examples/savelist.py')
+    submit_dir = str(tmpdir.mkdir('submit'))
+
+    job = Job('testjob', example_script, submit=submit_dir)
+    job.build()
+    i = _iter_job_args(job)
+    with pytest.raises(StopIteration):
+        i = _iter_job_args(job)
+        node_name, arg = next(i)

--- a/pycondor/tests/test_dagman.py
+++ b/pycondor/tests/test_dagman.py
@@ -49,22 +49,23 @@ def test_job_arg_name_files(tmpdir):
     example_script = os.path.join('examples/savelist.py')
     submit_dir = str(tmpdir.mkdir('submit'))
 
-    job = pycondor.Job('testjob', example_script, submit=submit_dir)
-    job.add_arg('arg', name='argname')
-    dagman = pycondor.Dagman('testdagman', submit=submit_dir)
-    dagman.add_job(job)
-    dagman.build(fancyname=True)
+    for fancyname in [True, False]:
+        job = pycondor.Job('testjob', example_script, submit=submit_dir)
+        job.add_arg('arg', name='argname')
+        dagman = pycondor.Dagman('testdagman', submit=submit_dir)
+        dagman.add_job(job)
+        dagman.build(fancyname=fancyname)
 
-    with open(dagman.submit_file, 'r') as dagman_submit_file:
-        dagman_submit_lines = dagman_submit_file.readlines()
+        with open(dagman.submit_file, 'r') as dagman_submit_file:
+            dagman_submit_lines = dagman_submit_file.readlines()
 
-    # Get root of the dagman submit file (submit file basename without .submit)
-    submit_file_line = dagman_submit_lines[0]
-    submit_file_basename = submit_file_line.split('/')[-1].rstrip()
-    submit_file_root = os.path.splitext(submit_file_basename)[0]
-    # Get job_name variable (used to built error/log/output file basenames)
-    jobname_line = dagman_submit_lines[2]
-    jobname = jobname_line.split('"')[-2]
-    other_file_root = '_'.join(jobname.split('_')[:-1])
+        # Get root of the dagman submit file (submit file basename w/o .submit)
+        submit_file_line = dagman_submit_lines[0]
+        submit_file_basename = submit_file_line.split('/')[-1].rstrip()
+        submit_file_root = os.path.splitext(submit_file_basename)[0]
+        # Get job_name variable (used to built error/log/output file basenames)
+        jobname_line = dagman_submit_lines[2]
+        jobname = jobname_line.split('"')[-2]
+        other_file_root = '_'.join(jobname.split('_')[:-1])
 
-    assert submit_file_root == other_file_root
+        assert submit_file_root == other_file_root

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -1,15 +1,15 @@
 
 import os
 import pytest
-import pycondor
-from .utils import clear_pycondor_environment_variables
+from pycondor import Job
+from pycondor.tests.utils import clear_pycondor_environment_variables
 
 clear_pycondor_environment_variables()
 
 
 def test_add_arg_type_fail():
     with pytest.raises(TypeError) as excinfo:
-        job = pycondor.Job('jobname', 'jobex')
+        job = Job('jobname', 'jobex')
         job.add_arg(50)
     error = 'arg must be a string'
     assert error == str(excinfo.value)
@@ -17,7 +17,7 @@ def test_add_arg_type_fail():
 
 def test_add_arg_name_type_fail():
     with pytest.raises(TypeError) as excinfo:
-        job = pycondor.Job('jobname', 'jobex')
+        job = Job('jobname', 'jobex')
         job.add_arg('arg', name=23.12)
     error = 'name must be a string'
     assert error == str(excinfo.value)
@@ -25,7 +25,7 @@ def test_add_arg_name_type_fail():
 
 def test_add_arg_retry_type_fail():
     with pytest.raises(TypeError) as excinfo:
-        job = pycondor.Job('jobname', 'jobex')
+        job = Job('jobname', 'jobex')
         job.add_arg('arg', retry='10')
     error = 'retry must be an int'
     assert error == str(excinfo.value)
@@ -33,7 +33,7 @@ def test_add_arg_retry_type_fail():
 
 def test_add_child_type_fail():
     with pytest.raises(TypeError) as excinfo:
-        job = pycondor.Job('jobname', 'jobex')
+        job = Job('jobname', 'jobex')
         job.add_child('childjob')
     error = 'add_child() is expecting a Job or Dagman instance. ' + \
             'Got an object of type {}'.format(type('childjob'))
@@ -42,13 +42,13 @@ def test_add_child_type_fail():
 
 def test_add_children_type_fail():
     with pytest.raises(TypeError):
-        job = pycondor.Job('jobname', 'jobex')
+        job = Job('jobname', 'jobex')
         job.add_children([1, 2, 3, 4])
 
 
 def test_add_parent_type_fail():
     with pytest.raises(TypeError) as excinfo:
-        job = pycondor.Job('jobname', 'jobex')
+        job = Job('jobname', 'jobex')
         job.add_parent('parentjob')
     error = 'add_parent() is expecting a Job or Dagman instance. ' + \
             'Got an object of type {}'.format(type('parentjob'))
@@ -57,14 +57,14 @@ def test_add_parent_type_fail():
 
 def test_add_parents_type_fail():
     with pytest.raises(TypeError):
-        job = pycondor.Job('jobname', 'jobex')
+        job = Job('jobname', 'jobex')
         job.add_parents([1, 2, 3, 4])
 
 
 def test_build_executeable_not_found_fail():
     with pytest.raises(IOError) as excinfo:
         ex = '/path/to/executable'
-        job = pycondor.Job('jobname', ex)
+        job = Job('jobname', ex)
         job.build(makedirs=False)
     error = 'The executable {} does not exist'.format(ex)
     assert error == str(excinfo.value)
@@ -79,8 +79,7 @@ def test_queue_written_to_submit_file(tmpdir):
     submit_dir = str(tmpdir.mkdir('submit'))
 
     # Build Job object with queue=5
-    job = pycondor.Job('jobname', example_script,
-                       submit=submit_dir, queue=5)
+    job = Job('jobname', example_script, submit=submit_dir, queue=5)
     job.build(fancyname=False)
 
     # Read the built submit file and check that the 'queue 5' is
@@ -97,7 +96,7 @@ def test_job_env_variable_dir(tmpdir):
         os.environ['PYCONDOR_{}_DIR'.format(dir_name.upper())] = dir_path
 
     example_script = os.path.join('examples/savelist.py')
-    job = pycondor.Job('jobname', example_script)
+    job = Job('jobname', example_script)
     job.build()
     for dir_name in ['submit', 'output', 'error', 'log']:
         tmpdir_path = os.path.join(str(tmpdir), dir_name)

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -103,3 +103,5 @@ def test_job_env_variable_dir(tmpdir):
         tmpdir_path = os.path.join(str(tmpdir), dir_name)
         job_path = os.path.dirname(getattr(job, '{}_file'.format(dir_name)))
         assert tmpdir_path == job_path
+
+    clear_pycondor_environment_variables()


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/jrbourbeau/pycondor/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->

Fixes #49

#### What does this pull request implement/fix? Explain your changes.

Currently, when a Job is added to a `Dagman` submit file the nodes for the `Job` args are of the format `jobname_arg_idx`. This PR changes this format to be `jobname_argname` if a named argument is added to a `Job`, and keeps the original node name convention for non-named arguments. 
