### PR TITLE
Add dag parameter to Job and Dagman

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,11 +11,12 @@ Version 0.2.1 (TBD)
 
 **New Features**:
 
-* 
+* Added ``dag`` parameter to ``Job`` and ``Dagman`` object initializations. (See `PR #67 <https://github.com/jrbourbeau/pycondor/pull/67>`_)
+
 
 **Changes**:
 
-* Adds a check for illegal characters in Dagman submit file node names when running HTCondor version 8.7.2 or newer. (See `PR #66 <https://github.com/jrbourbeau/pycondor/pull/66>`_)
+* Added a check for illegal characters in Dagman submit file node names when running HTCondor version 8.7.2 or newer. (See `PR #66 <https://github.com/jrbourbeau/pycondor/pull/66>`_)
 
 **Bug Fixes**:
 

--- a/pycondor/basenode.py
+++ b/pycondor/basenode.py
@@ -7,7 +7,8 @@ from . import utils
 
 class BaseNode(object):
 
-    def __init__(self, name, submit=None, extra_lines=None, verbose=0):
+    def __init__(self, name, submit=None, extra_lines=None, dag=None,
+                 verbose=0):
 
         # Validate user input
         if extra_lines and not isinstance(extra_lines, (str, list, tuple)):
@@ -18,6 +19,9 @@ class BaseNode(object):
         self.name = utils.string_rep(name)
         self.submit = submit
         self.extra_lines = extra_lines
+        self.dag = dag
+        if dag is not None:
+            dag._add_node(self)
         self._built = False
 
         self.parents = []

--- a/pycondor/dagman.py
+++ b/pycondor/dagman.py
@@ -109,6 +109,10 @@ class Dagman(BaseNode):
 
         .. versionadded:: 0.1.1
 
+    dag : Dagman, optional
+        If specified, Dagman will be added to dag as a subdag
+        (default is None).
+
     verbose : int, optional
         Level of logging verbosity option are 0-warning, 1-info,
         2-debugging (default is 0).
@@ -126,9 +130,10 @@ class Dagman(BaseNode):
         List of child Jobs and Dagmans. Ensures that Jobs and Dagmans in the
         children list will be submitted only after this Dagman has completed.
     """
-    def __init__(self, name, submit=None, extra_lines=None, verbose=0):
+    def __init__(self, name, submit=None, extra_lines=None, dag=None,
+                 verbose=0):
 
-        super(Dagman, self).__init__(name, submit, extra_lines, verbose)
+        super(Dagman, self).__init__(name, submit, extra_lines, dag, verbose)
 
         self.nodes = []
         self._has_bad_node_names = False
@@ -150,6 +155,9 @@ class Dagman(BaseNode):
 
     def __len__(self):
         return len(self.nodes)
+
+    def __contains__(self, item):
+        return item in self.nodes
 
     def _hasnode(self, node):
         return node in self.nodes

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -82,7 +82,10 @@ class Job(BaseNode):
     extra_lines : list or None, optional
         List of additional lines to be added to submit file.
 
-    verbose : int
+    dag : Dagman, optional
+        If specified, Job will be added to dag (default is None).
+
+    verbose : int, optional
         Level of logging verbosity option are 0-warning, 1-info,
         2-debugging (default is 0).
 
@@ -113,9 +116,9 @@ class Job(BaseNode):
                  submit=None, request_memory=None, request_disk=None,
                  request_cpus=None, getenv=True, universe='vanilla',
                  initialdir=None, notification='never', requirements=None,
-                 queue=None, extra_lines=None, verbose=0):
+                 queue=None, extra_lines=None, dag=None, verbose=0):
 
-        super(Job, self).__init__(name, submit, extra_lines, verbose)
+        super(Job, self).__init__(name, submit, extra_lines, dag, verbose)
 
         self.executable = utils.string_rep(executable)
         self.error = error

--- a/pycondor/tests/test_dagman.py
+++ b/pycondor/tests/test_dagman.py
@@ -234,3 +234,22 @@ def test_dagman_env_variable_dir(tmpdir):
     assert submit_dir == submit_path
 
     clear_pycondor_environment_variables()
+
+
+def test_dagman_dag_parameter(tmpdir):
+    # Test that a Dagman is added to a Dagman (as a subdag) when dag is given
+    submit_dir = str(tmpdir.join('submit'))
+    dag = Dagman('dagman', submit=submit_dir)
+    subdag = Dagman('subdag', submit=submit_dir, dag=dag)
+
+    assert subdag in dag
+
+
+def test_add_subdag_dag_parameter_equality(tmpdir):
+    submit_dir = str(tmpdir.join('submit'))
+    dag = Dagman('dagman', submit=submit_dir)
+    subdag_1 = Dagman('subdag_1', submit=submit_dir, dag=dag)
+    subdag_2 = Dagman('subdag_2', submit=submit_dir)
+    dag.add_subdag(subdag_2)
+
+    assert dag.nodes == [subdag_1, subdag_2]

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -1,7 +1,7 @@
 
 import os
 import pytest
-from pycondor import Job
+from pycondor import Job, Dagman
 from pycondor.utils import clear_pycondor_environment_variables
 
 clear_pycondor_environment_variables()
@@ -185,3 +185,22 @@ def test_retry_job_raises():
     error = ('Retrying failed Jobs is only available when submitting '
              'from a Dagman.')
     assert error == str(excinfo.value)
+
+
+def test_job_dag_parameter(tmpdir):
+    # Test that a Job is added to a Dagman when dag parameter given
+    submit_dir = str(tmpdir.join('submit'))
+    dag = Dagman('dagman', submit=submit_dir)
+    job = Job('job', example_script, dag=dag)
+
+    assert job in dag
+
+
+def test_add_job_dag_parameter_equality(tmpdir):
+    submit_dir = str(tmpdir.join('submit'))
+    dag = Dagman('dagman', submit=submit_dir)
+    job_1 = Job('job_1', example_script, dag=dag)
+    job_2 = Job('job_2', example_script)
+    dag.add_job(job_2)
+
+    assert dag.nodes == [job_1, job_2]


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/jrbourbeau/pycondor/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->
Fixes #64. This PR adds a `dag` parameter to the `Job` and `Dagman` initializations .
