### PR TITLE
Deprecates kwargs for submit_job and submit_dag

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -29,7 +29,7 @@ install:
     - pip install -r requirements/test.txt
 
 script:
-    - pytest --cov=pycondor pycondor
+    - pytest --cov=pycondor -m "not needs_condor" pycondor
     - flake8 pycondor
     - bash ci/build_docs.sh
 

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -12,11 +12,12 @@ Version 0.2.1 (TBD)
 **New Features**:
 
 * Added ``dag`` parameter to ``Job`` and ``Dagman`` object initializations. (See `PR #67 <https://github.com/jrbourbeau/pycondor/pull/67>`_)
-
+* Added ``submit_options`` parameter to ``Job.submit_job`` and ``Dagman.submit_dag`` methods. ``kwargs`` and ``maxjobs`` parameters for these methods are deprecated in favor of ``submit_options``. (See `PR #71 <https://github.com/jrbourbeau/pycondor/pull/71>`_)
 
 **Changes**:
 
 * Added a check for illegal characters in Dagman submit file node names when running HTCondor version 8.7.2 or newer. (See `PR #66 <https://github.com/jrbourbeau/pycondor/pull/66>`_)
+
 
 **Bug Fixes**:
 

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -2,6 +2,7 @@
 import os
 import subprocess
 from collections import namedtuple
+import warnings
 
 from . import utils
 from .basenode import BaseNode
@@ -372,24 +373,32 @@ class Job(BaseNode):
 
         return
 
-    def submit_job(self, **kwargs):
+    def submit_job(self, submit_options=None, **kwargs):
         """Submits Job to condor
 
         Parameters
         ----------
-        kwargs : dict, optional
-            Any additional options you would like specified when
-            ``condor_submit`` is called (see `HTCondor documentation
+        submit_options : str, optional
+            Options to be passed to ``condor_submit`` for this Job
+            (see the `condor_submit documentation
             <http://research.cs.wisc.edu/htcondor/manual/current/condor_submit.html>`_
-            for possible options). For example, if you would like to add
-            ``-maxjobs 1000`` to the ``condor_submit`` command, then
-            ``kwargs = {'-maxjobs': 1000}``.
+            for possible options).
+
+        kwargs : dict, optional
+            .. deprecated:: 0.2.1
+               Use ``submit_options`` instead.
 
         Returns
         -------
         self : object
             Returns self.
 
+        Examples
+        --------
+        >>> import pycondor
+        >>> job = pycondor.Job('myjob', 'myscript.py')
+        >>> job.build()
+        >>> job.submit_job(submit_options='-maxjobs 1000 -interactive')
         """
         # Ensure that submit file has been written
         if not self._built:
@@ -404,16 +413,26 @@ class Job(BaseNode):
                              'Interjob relationships requires Dagman.')
 
         # Construct and execute condor_submit command
-        command = 'condor_submit {}'.format(self.submit_file)
-        for option in kwargs:
-            command += ' {} {}'.format(option, kwargs[option])
+        warnings.simplefilter("always", DeprecationWarning)
+        command = 'condor_submit'
+        if submit_options is not None:
+            command += ' {}'.format(submit_options)
+        if kwargs:
+            dep_mes = ('kwargs for submit_job are deprecated. Use the '
+                       'submit_options parameter instead. kwargs will '
+                       'be removed in version 0.2.2.')
+            warnings.warn(dep_mes, DeprecationWarning)
+            for option in kwargs:
+                command += ' {} {}'.format(option, kwargs[option])
+        command += ' {}'.format(self.submit_file)
         proc = subprocess.Popen([command], stdout=subprocess.PIPE, shell=True)
         out, err = proc.communicate()
         print(out)
 
-        return
+        return self
 
-    def build_submit(self, makedirs=True, fancyname=True, **kwargs):
+    def build_submit(self, makedirs=True, fancyname=True, submit_options=None,
+                     **kwargs):
         """Calls build and submit sequentially
 
         Parameters
@@ -428,13 +447,15 @@ class Job(BaseNode):
             file becomes ``jobname_YYYYMMD_id``. This is useful when running
             several Jobs of the same name (default is ``True``).
 
-        kwargs : dict, optional
-            Any additional options you would like specified when
-            ``condor_submit`` is called (see `HTCondor documentation
+        submit_options : str, optional
+            Options to be passed to ``condor_submit`` for this Job
+            (see the `condor_submit documentation
             <http://research.cs.wisc.edu/htcondor/manual/current/condor_submit.html>`_
-            for possible options). For example, if you would like to add
-            ``-maxjobs 1000`` to the ``condor_submit`` command, then
-            ``kwargs = {'-maxjobs': 1000}``.
+            for possible options).
+
+        kwargs : dict, optional
+            .. deprecated:: 0.2.1
+               Use ``submit_options`` instead.
 
         Returns
         -------
@@ -442,6 +463,6 @@ class Job(BaseNode):
             Returns self.
         """
         self.build(makedirs, fancyname)
-        self.submit_job(**kwargs)
+        self.submit_job(submit_options=submit_options, **kwargs)
 
-        return
+        return self

--- a/pycondor/tests/test_dagman.py
+++ b/pycondor/tests/test_dagman.py
@@ -291,3 +291,18 @@ def test_dagman_add_node_ignores_duplicates(tmpdir, dagman):
     dagman.add_job(job)
 
     assert dagman.nodes == [job]
+
+
+@pytest.mark.needs_condor
+def test_submit_dag_maxjobs_deprecation_message(dagman):
+    dagman.build()
+    with pytest.deprecated_call():
+        dagman.submit_dag(maxjobs=1000)
+
+
+@pytest.mark.needs_condor
+def test_submit_dag_kwargs_deprecation_message(dagman):
+    dagman.build()
+    with pytest.deprecated_call():
+        kwargs = {'-config': '/path/to/file'}
+        dagman.submit_dag(maxjobs=0, **kwargs)

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -150,6 +150,13 @@ def test_submit_job_children_raises(tmpdir, job):
     assert error == str(excinfo.value)
 
 
+def test_submit_job_kwargs_deprecation_message(tmpdir, job):
+    job.build()
+    with pytest.deprecated_call():
+        kwargs = {'-maxjobs': 1000}
+        job.submit_job(**kwargs)
+
+
 def test_add_args_raises(job):
     # Test that add_args won't accept non-iterable argument inputs
     args = 10


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/jrbourbeau/pycondor/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->

Fixes #70

#### What does this pull request implement/fix? Explain your changes.

Replace the `kwargs` in `submit_job` and `submit_dag` with a `submit_options` parameter.


