### PR TITLE
Adds __enter__ and __exit__ methods to Job and Dagman

### DIFF
--- a/pycondor/dagman.py
+++ b/pycondor/dagman.py
@@ -130,6 +130,24 @@ class Dagman(BaseNode):
     children : list
         List of child Jobs and Dagmans. Ensures that Jobs and Dagmans in the
         children list will be submitted only after this Dagman has completed.
+
+    Examples
+    --------
+    Basic usage:
+
+    >>> import pycondor
+    >>> dagman = pycondor.Dagman('dag_name')
+    >>> job = pycondor.Job('job_name', 'my_script.py', dag=dagman)
+    >>> dagman.build_submit()
+
+    Or as a context manager:
+
+    >>> import pycondor
+    >>> with pycondor.Dagman('dag_name') as dagman:
+    >>>     job = pycondor.Job('job_name', 'my_script.py', dag=dagman)
+
+    When using a ``Dagman`` as a context manager, the ``build_submit`` method
+    will be called automatically upon exiting the ``with`` block.
     """
     def __init__(self, name, submit=None, extra_lines=None, dag=None,
                  verbose=0):
@@ -159,6 +177,12 @@ class Dagman(BaseNode):
 
     def __contains__(self, item):
         return item in self.nodes
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.build_submit()
 
     def _hasnode(self, node):
         return node in self.nodes

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -107,10 +107,20 @@ class Job(BaseNode):
 
     Examples
     --------
+    Basic usage:
+
     >>> import pycondor
-    >>> job = pycondor.Job('myjob', 'myscript.py')
+    >>> job = pycondor.Job('job_name', 'my_script.py')
     >>> job.build_submit()
 
+    Or as a context manager:
+
+    >>> import pycondor
+    >>> with pycondor.Job('job_name', 'my_script.py') as job:
+    >>>     job.add_arg('--option1 --option2')
+
+    When using a ``Job`` as a context manager, the ``build_submit`` method
+    will be called automatically upon exiting the ``with`` block.
     """
 
     def __init__(self, name, executable, error=None, log=None, output=None,
@@ -154,6 +164,12 @@ class Job(BaseNode):
 
     def __len__(self):
         return len(self.args)
+
+    def __enter__(self):
+        return self
+
+    def __exit__(self, type, value, traceback):
+        self.build_submit()
 
     def add_arg(self, arg, name=None, retry=None):
         """Add argument to Job

--- a/pycondor/tests/test_dagman.py
+++ b/pycondor/tests/test_dagman.py
@@ -307,3 +307,7 @@ def test_submit_dag_kwargs_deprecation_message(dagman):
     with pytest.deprecated_call():
         kwargs = {'-config': '/path/to/file'}
         dagman.submit_dag(maxjobs=0, **kwargs)
+
+
+def test_dagman_context_manager_enter(dagman):
+    assert dagman.__enter__() is dagman


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/jrbourbeau/pycondor/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->

Fixes  #76

#### What does this pull request implement/fix? Explain your changes.

This PR adds `__enter__` and `__exit__` methods to the `Job` and `Dagman` classes so they can be used as context managers. 
