### PR TITLE
Fixes typo in pycondor monitor command

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -8,5 +8,4 @@ coverage:
         threshold: 1%
     patch:
       default:
-        target: auto
-        threshold: 1%
+        enabled: no

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -20,7 +20,7 @@ Version 0.4.0.dev0 (TBD)
 
 **Bug Fixes**:
 
-- 
+- Fixes typo in ``pycondor monitor`` that was still referencing the old ``dagman_progress`` command. (See `PR #81 <https://github.com/jrbourbeau/pycondor/pull/81>`_)
 
 
 Version 0.3.0 (2018-03-20)

--- a/pycondor/cli.py
+++ b/pycondor/cli.py
@@ -203,7 +203,7 @@ def monitor(time_, length, prog_char, file):
             else:
                 time.sleep(time_)
     except KeyboardInterrupt:
-        print('\nExiting dagman_progress...')
+        print('\nExiting pycondor monitor...')
         sys.exit()
 
 


### PR DESCRIPTION
#### What does this pull request implement/fix? Explain your changes.

Looks like there is a reference to `dagman_progress` that should be changed to `pycondor monitor`. This PR fixes this typo. 
