### PR TITLE
Removes deprecated submit kwargs and dagman_progress command

### DIFF
--- a/pycondor/cli.py
+++ b/pycondor/cli.py
@@ -209,53 +209,6 @@ def monitor(time_, length, prog_char, file):
 
 @cli.command(
     context_settings=CONTEXT_SETTINGS,
-    short_help='(Depreciated) Monitor Dagman progress',
-)
-# Using time_ variable name so no confusion with time module
-@click.option(
-    '-t',
-    '--time',
-    'time_',
-    default=30,
-    type=float,
-    show_default=True,
-    help='Time (in seconds) in between log checks',
-)
-@click.option(
-    '-l',
-    '--length',
-    default=30,
-    type=int,
-    show_default=True,
-    help='Length of the progress bar',
-)
-@click.option(
-    '--prog_char',
-    default='#',
-    show_default=True,
-    help='Progress bar character',
-)
-@click.argument(
-    'file',
-    type=click.Path(exists=True),
-)
-@click.pass_context
-def dagman_progress(ctx, time_, length, prog_char, file):
-    '''Prints Dagman progress bar to stdout
-
-    The dagman_progress command is now depreciated and will be removed in
-    version 0.2.2. Please use the new "pycondor monitor" command instead.
-    '''
-    warnings.simplefilter("always", DeprecationWarning)
-    dep_mes = ('The dagman_progress command is now depreciated and '
-               'will be removed in version 0.2.2. Please use the new '
-               '"pycondor monitor" command instead.')
-    warnings.warn(dep_mes, DeprecationWarning)
-    ctx.forward(monitor)
-
-
-@cli.command(
-    context_settings=CONTEXT_SETTINGS,
     short_help='Submit a Job',
 )
 @click.option(

--- a/pycondor/cli.py
+++ b/pycondor/cli.py
@@ -6,7 +6,6 @@ import time
 from collections import namedtuple
 import click
 from datetime import datetime
-import warnings
 
 from .job import Job
 

--- a/pycondor/dagman.py
+++ b/pycondor/dagman.py
@@ -337,7 +337,7 @@ class Dagman(BaseNode):
         return self
 
     @requires_command('condor_submit_dag')
-    def submit_dag(self, submit_options=None, maxjobs=3000, **kwargs):
+    def submit_dag(self, submit_options=None):
         """Submits Dagman to condor
 
         Parameters
@@ -348,40 +348,18 @@ class Dagman(BaseNode):
             <http://research.cs.wisc.edu/htcondor/manual/current/condor_submit_dag.html>`_
             for possible options).
 
-        maxjobs : int, optional
-            .. deprecated:: 0.2.1
-               Use ``submit_options`` instead.
-
-        kwargs : dict, optional
-            .. deprecated:: 0.2.1
-               Use ``submit_options`` instead.
-
         Returns
         -------
         self : object
             Returns self.
         """
         # Construct condor_submit_dag command
-        warnings.simplefilter("always", DeprecationWarning)
         command = 'condor_submit_dag'
         if submit_options is not None:
             command += ' {}'.format(submit_options)
-        if maxjobs:
-            maxjobs_dep_mes = ('maxjobs for submit_dag is deprecated. Use '
-                               'the submit_options parameter instead. '
-                               'maxjobs parameter will be removed in version '
-                               '0.2.2.')
-            warnings.warn(maxjobs_dep_mes, DeprecationWarning)
-            command += ' -maxjobs {}'.format(maxjobs)
-        if kwargs:
-            kwargs_dep_mes = ('kwargs for submit_dag are deprecated. Use the '
-                              'submit_options parameter instead. kwargs will '
-                              'be removed in version 0.2.2.')
-            warnings.warn(kwargs_dep_mes, DeprecationWarning)
-            for option in kwargs:
-                command += ' {} {}'.format(option, kwargs[option])
         command += ' {}'.format(self.submit_file)
-        submit_dag_proc = subprocess.Popen([command], stdout=subprocess.PIPE,
+        submit_dag_proc = subprocess.Popen([command],
+                                           stdout=subprocess.PIPE,
                                            shell=True)
         # Check that there are no illegal node names for newer condor versions
         condor_version = get_condor_version()
@@ -401,8 +379,7 @@ class Dagman(BaseNode):
         return self
 
     @requires_command('condor_submit_dag')
-    def build_submit(self, makedirs=True, fancyname=True, submit_options=None,
-                     maxjobs=3000, **kwargs):
+    def build_submit(self, makedirs=True, fancyname=True, submit_options=None):
         """Calls build and submit sequentially
 
         Parameters
@@ -423,22 +400,12 @@ class Dagman(BaseNode):
             <http://research.cs.wisc.edu/htcondor/manual/current/condor_submit_dag.html>`_
             for possible options).
 
-        maxjobs : int, optional
-            .. deprecated:: 0.2.1
-               Use ``submit_options`` instead.
-
-        kwargs : dict, optional
-
-            .. deprecated:: 0.2.1
-               Use ``submit_options`` instead.
-
         Returns
         -------
         self : object
             Returns self.
         """
         self.build(makedirs, fancyname)
-        self.submit_dag(maxjobs=maxjobs, submit_options=submit_options,
-                        **kwargs)
+        self.submit_dag(submit_options=submit_options)
 
         return self

--- a/pycondor/dagman.py
+++ b/pycondor/dagman.py
@@ -1,7 +1,6 @@
 
 import os
 import subprocess
-import warnings
 
 from .utils import checkdir, get_condor_version, requires_command
 from .basenode import BaseNode

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -2,7 +2,6 @@
 import os
 import subprocess
 from collections import namedtuple
-import warnings
 
 from .utils import checkdir, string_rep, requires_command
 from .basenode import BaseNode

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -370,7 +370,7 @@ class Job(BaseNode):
         return
 
     @requires_command('condor_submit')
-    def submit_job(self, submit_options=None, **kwargs):
+    def submit_job(self, submit_options=None):
         """Submits Job to condor
 
         Parameters
@@ -380,10 +380,6 @@ class Job(BaseNode):
             (see the `condor_submit documentation
             <http://research.cs.wisc.edu/htcondor/manual/current/condor_submit.html>`_
             for possible options).
-
-        kwargs : dict, optional
-            .. deprecated:: 0.2.1
-               Use ``submit_options`` instead.
 
         Returns
         -------
@@ -410,17 +406,9 @@ class Job(BaseNode):
                              'Interjob relationships requires Dagman.')
 
         # Construct and execute condor_submit command
-        warnings.simplefilter("always", DeprecationWarning)
         command = 'condor_submit'
         if submit_options is not None:
             command += ' {}'.format(submit_options)
-        if kwargs:
-            dep_mes = ('kwargs for submit_job are deprecated. Use the '
-                       'submit_options parameter instead. kwargs will '
-                       'be removed in version 0.2.2.')
-            warnings.warn(dep_mes, DeprecationWarning)
-            for option in kwargs:
-                command += ' {} {}'.format(option, kwargs[option])
         command += ' {}'.format(self.submit_file)
         proc = subprocess.Popen([command], stdout=subprocess.PIPE, shell=True)
         out, err = proc.communicate()
@@ -429,8 +417,7 @@ class Job(BaseNode):
         return self
 
     @requires_command('condor_submit')
-    def build_submit(self, makedirs=True, fancyname=True, submit_options=None,
-                     **kwargs):
+    def build_submit(self, makedirs=True, fancyname=True, submit_options=None):
         """Calls build and submit sequentially
 
         Parameters
@@ -451,16 +438,12 @@ class Job(BaseNode):
             <http://research.cs.wisc.edu/htcondor/manual/current/condor_submit.html>`_
             for possible options).
 
-        kwargs : dict, optional
-            .. deprecated:: 0.2.1
-               Use ``submit_options`` instead.
-
         Returns
         -------
         self : object
             Returns self.
         """
         self.build(makedirs, fancyname)
-        self.submit_job(submit_options=submit_options, **kwargs)
+        self.submit_job(submit_options=submit_options)
 
         return self

--- a/pycondor/tests/test_cli.py
+++ b/pycondor/tests/test_cli.py
@@ -102,21 +102,6 @@ def test_monitor_file_raises():
     assert result.output.replace('\r', '') == expected_output
 
 
-def test_dagman_progress_deprecation_message():
-    command = 'dagman_progress {}'.format(example_dagman_submit)
-    proc = subprocess.Popen([command],
-                            stderr=subprocess.PIPE,
-                            shell=True)
-    _, err = proc.communicate()
-
-    deprecation_message = ('DeprecationWarning: The dagman_progress command '
-                           'is now depreciated and will be removed in version '
-                           '0.2.2. Please use the new "pycondor monitor" '
-                           'command instead.')
-
-    assert deprecation_message in str(err)
-
-
 def test_submit_file_raises():
     non_exist_executable = '/this/does/not/exist.py'
 

--- a/pycondor/tests/test_cli.py
+++ b/pycondor/tests/test_cli.py
@@ -2,7 +2,6 @@
 import pytest
 import os
 from datetime import datetime
-import subprocess
 from click.testing import CliRunner
 
 import pycondor

--- a/pycondor/tests/test_dagman.py
+++ b/pycondor/tests/test_dagman.py
@@ -292,18 +292,3 @@ def test_dagman_add_node_ignores_duplicates(tmpdir, dagman):
     dagman.add_job(job)
 
     assert dagman.nodes == [job]
-
-
-@pytest.mark.needs_condor
-def test_submit_dag_maxjobs_deprecation_message(dagman):
-    dagman.build()
-    with pytest.deprecated_call():
-        dagman.submit_dag(maxjobs=1000)
-
-
-@pytest.mark.needs_condor
-def test_submit_dag_kwargs_deprecation_message(dagman):
-    dagman.build()
-    with pytest.deprecated_call():
-        kwargs = {'-config': '/path/to/file'}
-        dagman.submit_dag(maxjobs=0, **kwargs)

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -182,14 +182,6 @@ def test_submit_job_children_raises(tmpdir, job, monkeypatch_condor_submit):
     assert error == str(excinfo.value)
 
 
-def test_submit_job_kwargs_deprecation_message(tmpdir, job,
-                                               monkeypatch_condor_submit):
-    job.build()
-    with pytest.deprecated_call():
-        kwargs = {'-maxjobs': 1000}
-        job.submit_job(**kwargs)
-
-
 def test_add_args_raises(job):
     # Test that add_args won't accept non-iterable argument inputs
     args = 10


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### What does this pull request implement/fix? Explain your changes.

This PR removes deprecated keyword arguments to the `Job.submit_job` and `Dagman.submit_dag` methods as well as the deprecated `dagman_progress` command. 