### PR TITLE
Add an option to initialize pycondor jobs with arguments.

### DIFF
--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -85,7 +85,7 @@ class Job(BaseNode):
     dag : Dagman, optional
         If specified, Job will be added to dag (default is None).
 
-    arg : str
+    argument : str
         Argument with which to initialize the list of arguments for the Job.
 
     retry : int or None, optional
@@ -125,7 +125,7 @@ class Job(BaseNode):
                  submit=None, request_memory=None, request_disk=None,
                  request_cpus=None, getenv=True, universe='vanilla',
                  initialdir=None, notification='never', requirements=None,
-                 queue=None, extra_lines=None, dag=None, arg=None,
+                 queue=None, extra_lines=None, dag=None, argument=None,
                  retry=None, verbose=0):
 
         super(Job, self).__init__(name, submit, extra_lines, dag, verbose)
@@ -146,8 +146,8 @@ class Job(BaseNode):
         self.retry = retry
 
         self.args = []
-        if arg is not None:
-            self.add_arg(arg)
+        if argument is not None:
+            self.add_arg(argument)
 
         self.logger.debug('{} initialized'.format(self.name))
 

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -143,6 +143,9 @@ class Job(BaseNode):
         self.notification = notification
         self.requirements = requirements
         self.queue = queue
+
+        if retry and not isinstance(retry, int):
+            raise TypeError('retry must be an int')
         self.retry = retry
 
         self.args = []

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -85,6 +85,15 @@ class Job(BaseNode):
     dag : Dagman, optional
         If specified, Job will be added to dag (default is None).
 
+    arg : str
+        Argument with which to initialize the list of arguments for the Job.
+
+    retry : int or None, optional
+        Option to specify the number of times to retry for all arguments in
+        the job. This can be superseded for arguments added via the add_arg()
+        method. Default number of retries is 0. Note: this feature is only
+        available to Jobs that are submitted via a Dagman.
+
     verbose : int, optional
         Level of logging verbosity option are 0-warning, 1-info,
         2-debugging (default is 0).
@@ -116,7 +125,8 @@ class Job(BaseNode):
                  submit=None, request_memory=None, request_disk=None,
                  request_cpus=None, getenv=True, universe='vanilla',
                  initialdir=None, notification='never', requirements=None,
-                 queue=None, extra_lines=None, dag=None, verbose=0):
+                 queue=None, extra_lines=None, dag=None, arg=None,
+                 retry=None, verbose=0):
 
         super(Job, self).__init__(name, submit, extra_lines, dag, verbose)
 
@@ -133,8 +143,11 @@ class Job(BaseNode):
         self.notification = notification
         self.requirements = requirements
         self.queue = queue
+        self.retry = retry
 
         self.args = []
+        if arg is not None:
+            self.add_arg(arg)
 
         self.logger.debug('{} initialized'.format(self.name))
 
@@ -191,7 +204,10 @@ class Job(BaseNode):
         elif retry and not isinstance(retry, int):
             raise TypeError('retry must be an int')
 
-        job_arg = JobArg(arg=arg, name=name, retry=retry)
+        if retry is not None:
+            job_arg = JobArg(arg=arg, name=name, retry=retry)
+        else:
+            job_arg = JobArg(arg=arg, name=name, retry=self.retry)
         self.args.append(job_arg)
         self.logger.debug('Added argument \'{}\' to Job {}'.format(arg,
                                                                    self.name))

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -271,3 +271,16 @@ def test_job_args_warning(caplog, job):
     job.build()
     log_message = 'Consider using a Dagman in the future to help monitor jobs'
     assert log_message in caplog.text
+
+
+def test_init_arg_type_fail():
+    with pytest.raises(TypeError) as excinfo:
+        job_with_arg = Job('jobname', example_script, argument=50)
+    error = 'arg must be a string'
+    assert error == str(excinfo.value)
+
+def test_init_retry_type_fail(job):
+    with pytest.raises(TypeError) as excinfo:
+        job_with_retry = Job('jobname', example_script, retry='20')
+    error = 'retry must be an int'
+    assert error == str(excinfo.value)

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -277,11 +277,14 @@ def test_job_args_warning(caplog, job):
 def test_init_arg_type_fail():
     with pytest.raises(TypeError) as excinfo:
         job_with_arg = Job('jobname', example_script, argument=50)
+        job_with_arg.build()
     error = 'arg must be a string'
     assert error == str(excinfo.value)
+
 
 def test_init_retry_type_fail(job):
     with pytest.raises(TypeError) as excinfo:
         job_with_retry = Job('jobname', example_script, retry='20')
+        job_with_retry.build()
     error = 'retry must be an int'
     assert error == str(excinfo.value)


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/jrbourbeau/pycondor/issues) if one exists. For example,

Implements #89. 
-->


#### What does this pull request implement/fix? Explain your changes.

This pull request adds the option to initialize a Job with an argument.  In addition, it adds the option to set the number of retries for arguments of the Job.

#### Any other comments?

The retry option could be changed to just specify the number of retries for the argument given in initialization if setting it overall is not wanted.