### PR TITLE
Moves example script for tests to tests/ directory

### DIFF
--- a/pycondor/tests/example_script.py
+++ b/pycondor/tests/example_script.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python
+
+import argparse
+
+if __name__ == "__main__":
+    '''
+    Example script that generates and saves a list to file
+    '''
+
+    parser = argparse.ArgumentParser(description='Generates and saves a list to file')
+    parser.add_argument('--length', dest='length', type=int, default=10,
+                        help='Length of list to be generated and saved')
+    args = parser.parse_args()
+
+    print('Saving range({})...'.format(args.length))
+    with open('range_{}'.format(args.length), 'wb') as outputfile:
+        for i in range(args.length):
+          outputfile.write('{}\n'.format(i))

--- a/pycondor/tests/test_cli.py
+++ b/pycondor/tests/test_cli.py
@@ -11,14 +11,9 @@ from pycondor.cli import (line_to_datetime, progress_bar_str, Status, _states,
 
 clear_pycondor_environment_variables()
 
-pycondor_dir = os.path.dirname(pycondor.__file__)
-example_dagman_submit = os.path.join(pycondor_dir,
-                                     'tests',
-                                     'test_dagman.submit')
-example_script = os.path.join(pycondor_dir,
-                              '..',
-                              'examples',
-                              'savelist.py')
+here = os.path.abspath(os.path.dirname(__file__))
+example_script = os.path.join(here, 'example_script.py')
+example_dagman_submit = os.path.join(here, 'test_dagman.submit')
 
 
 def test_line_to_datetime():
@@ -65,8 +60,7 @@ def test_progress_bar_str_null_status():
 
 
 def test_status_generator():
-    dag_out_file = os.path.join(pycondor_dir,
-                                'tests',
+    dag_out_file = os.path.join(here,
                                 'exampledagman.submit.dagman.out')
 
     status_gen = status_generator(dag_out_file)

--- a/pycondor/tests/test_dagman.py
+++ b/pycondor/tests/test_dagman.py
@@ -9,7 +9,8 @@ from pycondor.utils import clear_pycondor_environment_variables
 
 clear_pycondor_environment_variables()
 
-example_script = os.path.join('examples/savelist.py')
+here = os.path.abspath(os.path.dirname(__file__))
+example_script = os.path.join(here, 'example_script.py')
 
 
 @pytest.fixture()

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -9,7 +9,8 @@ from pycondor.utils import clear_pycondor_environment_variables
 
 clear_pycondor_environment_variables()
 
-example_script = os.path.join('examples/savelist.py')
+here = os.path.abspath(os.path.dirname(__file__))
+example_script = os.path.join(here, 'example_script.py')
 
 
 @pytest.fixture()
@@ -135,14 +136,14 @@ def test_job_env_variable_dir(tmpdir, monkeypatch, env_var):
 def test_repr():
     default_job = Job('jobname', example_script)
     job_repr = repr(default_job)
-    expected_repr = ('Job(name=jobname, executable=savelist.py, '
+    expected_repr = ('Job(name=jobname, executable=example_script.py, '
                      'getenv=True, notification=never, submit={}, '
                      'universe=vanilla)'.format(os.getcwd()))
     assert job_repr == expected_repr
 
     job_non_default = Job('jobname', example_script, queue=2)
     job_repr = repr(job_non_default)
-    expected_repr = ('Job(name=jobname, executable=savelist.py, getenv=True, '
+    expected_repr = ('Job(name=jobname, executable=example_script.py, getenv=True, '
                      'notification=never, queue=2, submit={}, '
                      'universe=vanilla)'.format(os.getcwd()))
     assert job_repr == expected_repr


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

This PR moves the example script being used for tests to the `pycondor/tests` directory (currently a script from the `examples/` directory is being used). 

Thanks for pointing this out @zdgriffith! 