### PR TITLE
Changes sphinx code highlighting style to default

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -83,7 +83,7 @@ language = 'en'
 exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 
 # The name of the Pygments (syntax highlighting) style to use.
-pygments_style = 'sphinx'
+pygments_style = 'default'
 
 # If true, `todo` and `todoList` produce output, else they produce nothing.
 todo_include_todos = False


### PR DESCRIPTION
This PR changes the code highlighting style used in the sphinx docs from this:

<img width="1099" alt="screen shot 2018-05-01 at 1 32 08 pm" src="https://user-images.githubusercontent.com/11656932/39487312-5f77d8de-4d44-11e8-8582-e6ea64fdb859.png">

to this:

<img width="1096" alt="screen shot 2018-05-01 at 1 32 34 pm" src="https://user-images.githubusercontent.com/11656932/39487318-65433e16-4d44-11e8-9bce-a658f236b24b.png">

I think the updated version is easier to read.  