### PR TITLE
Removes Job executable check

### DIFF
--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -247,9 +247,6 @@ class Job(BaseNode):
             raise NotImplementedError(message)
 
         # Check that paths/files exist
-        if not os.path.exists(self.executable):
-            raise IOError(
-                'The executable {} does not exist'.format(self.executable))
         for directory in [self.submit, self.log, self.output, self.error]:
             if directory is not None:
                 checkdir(directory + '/', makedirs)

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -80,16 +80,6 @@ def test_add_parents_type_fail(job):
         job.add_parents([1, 2, 3, 4])
 
 
-def test_build_executeable_not_found_fail(tmpdir):
-    submit_dir = str(tmpdir.mkdir('submit'))
-    with pytest.raises(IOError) as excinfo:
-        ex = '/path/to/executable'
-        job = Job('jobname', ex, submit=submit_dir)
-        job.build(makedirs=False)
-    error = 'The executable {} does not exist'.format(ex)
-    assert error == str(excinfo.value)
-
-
 def test_queue_written_to_submit_file(tmpdir):
     # Test to check that the queue parameter is properly written
     # to submit file when Job is created. See issue #38.


### PR DESCRIPTION
#### What does this pull request implement/fix? Explain your changes.

This PR removes a check that `Job` executable paths must exist when a `Job` is being built. Having this check doesn't allow for [interactive jobs](http://chtc.cs.wisc.edu/inter-submit.shtml) and situations where the executable is being transferred to the execute node. 