### PR TITLE
Adds FutureWarning for change in Job default values

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -15,6 +15,7 @@ Version 0.4.0.dev0 (TBD)
 
 **Changes**:
 
+- Adds ``FutureWarning`` about changing the default values of the ``universe``, ``getenv``, and ``notification`` parameters for ``Job`` objects to None. (See `PR #98 <https://github.com/jrbourbeau/pycondor/pull/98>`_)
 - Removes check that a ``Job`` executable path must exist locally when the ``Job`` is being built.
   (See `PR #96 <https://github.com/jrbourbeau/pycondor/pull/96>`_)
 - Adds the option to initialize a ``Job`` with an argument. (See `PR #90 <https://github.com/jrbourbeau/pycondor/pull/90>`_)

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -131,10 +131,10 @@ class Job(BaseNode):
 
         super(Job, self).__init__(name, submit, extra_lines, dag, verbose)
 
+        # TODO: Remove after 0.5.0 release
         future_msg = ('The default values for the universe, getenv, and '
                       'notification Job parameters will be changed to None '
                       'in release version 0.5.0.')
-        warnings.simplefilter('always')
         warnings.warn(future_msg, FutureWarning)
 
         self.executable = string_rep(executable)

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -134,6 +134,7 @@ class Job(BaseNode):
         future_msg = ('The default values for the universe, getenv, and '
                       'notification Job parameters will be changed to None '
                       'in release version 0.5.0.')
+        warnings.simplefilter('always')
         warnings.warn(future_msg, FutureWarning)
 
         self.executable = string_rep(executable)

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -2,6 +2,7 @@
 import os
 import subprocess
 from collections import namedtuple
+import warnings
 
 from .utils import checkdir, string_rep, requires_command
 from .basenode import BaseNode
@@ -129,6 +130,11 @@ class Job(BaseNode):
                  retry=None, verbose=0):
 
         super(Job, self).__init__(name, submit, extra_lines, dag, verbose)
+
+        future_msg = ('The default values for the universe, getenv, and '
+                      'notification Job parameters will be changed to None '
+                      'in release version 0.5.0.')
+        warnings.warn(future_msg, FutureWarning)
 
         self.executable = string_rep(executable)
         self.error = error

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -3,9 +3,11 @@ import os
 import sys
 import shutil
 from distutils import spawn
+import warnings
 import pytest
 from pycondor import Job, Dagman
 from pycondor.utils import clear_pycondor_environment_variables
+warnings.simplefilter('always')
 
 clear_pycondor_environment_variables()
 
@@ -281,13 +283,8 @@ def test_init_retry_type_fail(job):
 
 
 def test_job_default_param_future_warning():
-    with pytest.warns(FutureWarning) as record:
-        Job(name='jobname', executable=example_script)
-
-    # check that only one warning was raised
-    assert len(record) == 1
-    # check that the message matches
     future_msg = ('The default values for the universe, getenv, and '
                   'notification Job parameters will be changed to None '
                   'in release version 0.5.0.')
-    assert record[0].message.args[0] == future_msg
+    with pytest.warns(FutureWarning, match=future_msg):
+        Job(name='jobname', executable=example_script)

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -278,3 +278,16 @@ def test_init_retry_type_fail(job):
         job_with_retry.build()
     error = 'retry must be an int'
     assert error == str(excinfo.value)
+
+
+def test_job_default_param_future_warning():
+    with pytest.warns(FutureWarning) as record:
+        Job(name='jobname', executable=example_script)
+
+    # check that only one warning was raised
+    assert len(record) == 1
+    # check that the message matches
+    future_msg = ('The default values for the universe, getenv, and '
+                  'notification Job parameters will be changed to None '
+                  'in release version 0.5.0.')
+    assert record[0].message.args[0] == future_msg


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
<!-- Please provide a link to the respective issue on the issue tracker (https://github.com/jrbourbeau/pycondor/issues) if one exists. For example,

Fixes #<ISSUE_NUMBER>
-->

This PR adds a `FutureWarning` about changing the default values of the `universe`, `getenv`, and `notification` parameters for `Job` objects. 

ref #97. 
