### PR TITLE
Adds support for iterable arguments in Job init

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -11,15 +11,18 @@ Version 0.4.0.dev0 (TBD)
 
 **New Features**:
 
--
+- Adds the option to initialize a ``Job`` with an ``arguments`` parameter.
+  (See `PR #90 <https://github.com/jrbourbeau/pycondor/pull/90>`_ and
+  `PR #102 <https://github.com/jrbourbeau/pycondor/pull/102>`_)
+- Adds the option to initialize a ``Job`` with a ``retry`` parameter, which
+  sets the default number of retries for all arguments of the Job if given.
+  (See `PR #90 <https://github.com/jrbourbeau/pycondor/pull/90>`_)
 
 **Changes**:
 
 - Adds ``FutureWarning`` about changing the default values of the ``universe``, ``getenv``, and ``notification`` parameters for ``Job`` objects to None. (See `PR #98 <https://github.com/jrbourbeau/pycondor/pull/98>`_)
 - Removes check that a ``Job`` executable path must exist locally when the ``Job`` is being built.
   (See `PR #96 <https://github.com/jrbourbeau/pycondor/pull/96>`_)
-- Adds the option to initialize a ``Job`` with an argument. (See `PR #90 <https://github.com/jrbourbeau/pycondor/pull/90>`_)
-- Adds the ``retry`` attribute to ``Job``, which sets the default number of retries for all arguments of the Job if given. (See `PR #90 <https://github.com/jrbourbeau/pycondor/pull/90>`_)
 - Adds informative error message when ``Job.submit_job`` is called on a machine where the ``condor_submit`` command isn't available. (See `PR #83 <https://github.com/jrbourbeau/pycondor/pull/83>`_)
 - Removes deprecated ``maxjobs`` and ``kwargs`` parameters for the ``Job.submit_job``, ``Job.build_submit``, ``Dagman.submit_dag``, and ``Dagman.build_submit`` methods. Also removes the deprecated ``dagman_progress`` command. (See `PR #84 <https://github.com/jrbourbeau/pycondor/pull/84>`_)
 

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -87,7 +87,8 @@ class Job(BaseNode):
         If specified, Job will be added to dag (default is None).
 
     arguments : str or iterable, optional
-        Arguments with which to initialize the Job list of arguments.
+        Arguments with which to initialize the Job list of arguments
+        (default is None).
 
     retry : int or None, optional
         Option to specify the number of retries for all Job arguments. This

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -1,7 +1,7 @@
 
 import os
 import subprocess
-from collections import namedtuple
+from collections import namedtuple, Iterable
 import warnings
 
 from .utils import checkdir, string_rep, requires_command
@@ -86,8 +86,8 @@ class Job(BaseNode):
     dag : Dagman, optional
         If specified, Job will be added to dag (default is None).
 
-    argument : str
-        Argument with which to initialize the list of arguments for the Job.
+    arguments : str or iterable, optional
+        Arguments with which to initialize the Job list of arguments.
 
     retry : int or None, optional
         Option to specify the number of times to retry for all arguments in
@@ -102,7 +102,7 @@ class Job(BaseNode):
     Attributes
     ----------
     args : list
-        The list of arguments for this Job instance.
+        List of arguments for this Job instance.
 
     parents : list
         Only set when included in a Dagman. List of parent Jobs and Dagmans.
@@ -126,7 +126,7 @@ class Job(BaseNode):
                  submit=None, request_memory=None, request_disk=None,
                  request_cpus=None, getenv=True, universe='vanilla',
                  initialdir=None, notification='never', requirements=None,
-                 queue=None, extra_lines=None, dag=None, argument=None,
+                 queue=None, extra_lines=None, dag=None, arguments=None,
                  retry=None, verbose=0):
 
         super(Job, self).__init__(name, submit, extra_lines, dag, verbose)
@@ -156,8 +156,14 @@ class Job(BaseNode):
         self.retry = retry
 
         self.args = []
-        if argument is not None:
-            self.add_arg(argument)
+        if arguments is not None:
+            if isinstance(arguments, str):
+                self.add_arg(arguments)
+            elif isinstance(arguments, Iterable):
+                for arg in arguments:
+                    self.add_arg(arg)
+            else:
+                raise TypeError('arguments must be a string or an iterable')
 
         self.logger.debug('{} initialized'.format(self.name))
 
@@ -229,8 +235,8 @@ class Job(BaseNode):
 
         Parameters
         ----------
-        args : list or tuple
-            Series of arguments to append to the arguments list
+        args : iterable
+            Iterable of arguments to append to the arguments list
 
         Returns
         -------

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -90,10 +90,10 @@ class Job(BaseNode):
         Arguments with which to initialize the Job list of arguments.
 
     retry : int or None, optional
-        Option to specify the number of times to retry for all arguments in
-        the job. This can be superseded for arguments added via the add_arg()
-        method. Default number of retries is 0. Note: this feature is only
-        available to Jobs that are submitted via a Dagman.
+        Option to specify the number of retries for all Job arguments. This
+        can be superseded for arguments added via the add_arg() method.
+        Note: this feature is only available to Jobs that are submitted via a
+        Dagman (default is None; no retries).
 
     verbose : int, optional
         Level of logging verbosity option are 0-warning, 1-info,

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -266,15 +266,40 @@ def test_job_args_warning(caplog, job):
     assert log_message in caplog.text
 
 
-def test_init_arg_type_fail():
+def test_init_arguments():
+    arguments = 'my special argument'
+    job = Job(name='jobname',
+              executable=example_script,
+              arguments=arguments)
+    assert len(job.args) == 1
+    assert job.args[0].arg == arguments
+
+
+def test_init_arguments_type_fail():
     with pytest.raises(TypeError) as excinfo:
-        job_with_arg = Job('jobname', example_script, argument=50)
+        job_with_arg = Job(name='jobname',
+                           executable=example_script,
+                           arguments=50)
         job_with_arg.build()
-    error = 'arg must be a string'
+    error = 'arguments must be a string or an iterable'
     assert error == str(excinfo.value)
 
 
-def test_init_retry_type_fail(job):
+def test_init_retry():
+    # Test that global retry applies to add_arg without a retry specified and
+    # not when add_arg has a retry specified
+    job = Job(name='jobname',
+              executable=example_script,
+              retry=7)
+    job.add_arg('arg1')
+    job.add_arg('arg2', retry=3)
+
+    assert len(job.args) == 2
+    assert job.args[0].retry == 7
+    assert job.args[1].retry == 3
+
+
+def test_init_retry_type_fail():
     with pytest.raises(TypeError) as excinfo:
         job_with_retry = Job('jobname', example_script, retry='20')
         job_with_retry.build()

--- a/pycondor/tests/test_job.py
+++ b/pycondor/tests/test_job.py
@@ -275,6 +275,16 @@ def test_init_arguments():
     assert job.args[0].arg == arguments
 
 
+def test_init_arguments_iterable():
+    arguments = ['arg{}'.format(i) for i in range(10)]
+    job = Job(name='jobname',
+              executable=example_script,
+              arguments=arguments)
+    assert len(job.args) == len(arguments)
+    for jobarg, argument in zip(job.args, arguments):
+        assert jobarg.arg == argument
+
+
 def test_init_arguments_type_fail():
     with pytest.raises(TypeError) as excinfo:
         job_with_arg = Job(name='jobname',


### PR DESCRIPTION
This PR does two things:

1. Renames the `argument` parameter in the `Job.__init__` method `arguments`
2. Adds support for passing iterables to the `arguments` parameter