### PR TITLE
Changed format of condor_submit command in job.py and dagman.py

### DIFF
--- a/pycondor/dagman.py
+++ b/pycondor/dagman.py
@@ -360,8 +360,7 @@ class Dagman(BaseNode):
         command += ' {}'.format(self.submit_file)
         submit_dag_proc = subprocess.Popen(shlex.split(command),
                                            stdout=subprocess.PIPE,
-                                           stderr=subprocess.PIPE,
-                                           shell=True)
+                                           stderr=subprocess.PIPE)
         # Check that there are no illegal node names for newer condor versions
         condor_version = get_condor_version()
         if condor_version >= (8, 7, 2) and self._has_bad_node_names:

--- a/pycondor/dagman.py
+++ b/pycondor/dagman.py
@@ -1,6 +1,7 @@
 
 import os
 import subprocess
+import shlex
 
 from .utils import checkdir, get_condor_version, requires_command
 from .basenode import BaseNode
@@ -357,8 +358,9 @@ class Dagman(BaseNode):
         if submit_options is not None:
             command += ' {}'.format(submit_options)
         command += ' {}'.format(self.submit_file)
-        submit_dag_proc = subprocess.Popen(command,
+        submit_dag_proc = subprocess.Popen(shlex.split(command),
                                            stdout=subprocess.PIPE,
+                                           stderr=subprocess.PIPE,
                                            shell=True)
         # Check that there are no illegal node names for newer condor versions
         condor_version = get_condor_version()

--- a/pycondor/dagman.py
+++ b/pycondor/dagman.py
@@ -357,7 +357,7 @@ class Dagman(BaseNode):
         if submit_options is not None:
             command += ' {}'.format(submit_options)
         command += ' {}'.format(self.submit_file)
-        submit_dag_proc = subprocess.Popen([command],
+        submit_dag_proc = subprocess.Popen(command,
                                            stdout=subprocess.PIPE,
                                            shell=True)
         # Check that there are no illegal node names for newer condor versions

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -442,8 +442,7 @@ class Job(BaseNode):
         command += ' {}'.format(self.submit_file)
         proc = subprocess.Popen(shlex.split(command),
                                 stdout=subprocess.PIPE,
-                                stderr=subprocess.PIPE,
-                                shell=True)
+                                stderr=subprocess.PIPE)
         out, err = proc.communicate()
         print(out)
 

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -3,6 +3,7 @@ import os
 import subprocess
 from collections import namedtuple, Iterable
 import warnings
+import shlex
 
 from .utils import checkdir, string_rep, requires_command
 from .basenode import BaseNode
@@ -439,7 +440,10 @@ class Job(BaseNode):
         if submit_options is not None:
             command += ' {}'.format(submit_options)
         command += ' {}'.format(self.submit_file)
-        proc = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True)
+        proc = subprocess.Popen(shlex.split(command),
+                                stdout=subprocess.PIPE,
+                                stderr=subprocess.PIPE,
+                                shell=True)
         out, err = proc.communicate()
         print(out)
 

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -439,7 +439,7 @@ class Job(BaseNode):
         if submit_options is not None:
             command += ' {}'.format(submit_options)
         command += ' {}'.format(self.submit_file)
-        proc = subprocess.Popen([command], stdout=subprocess.PIPE, shell=True)
+        proc = subprocess.Popen(command, stdout=subprocess.PIPE, shell=True)
         out, err = proc.communicate()
         print(out)
 


### PR DESCRIPTION
<!-- Thank you for the pull request! -->

#### Reference Issue
Fixes #105 

#### What does this pull request implement/fix? Explain your changes.
The format of the condor_submit command did not work on Windows. This can be fixed by passing the command string to `subprocess.Popen()`, instead of as a string element of a list.

#### Any other comments?
I am working on Windows and therefore cannot determine whether this change affects Linux users.
