### PR TITLE
Remove dagman_progress from entry points

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -6,6 +6,23 @@
 Release Notes
 *************
 
+Version 0.5.0 (TBD)
+-------------------
+
+**New Features**:
+
+-
+
+**Changes**:
+
+-
+
+**Bug Fixes**:
+
+- Removes outdated reference to ``dagman_progress`` in ``entry_points`` of
+  ``setup.py``. (See `PR #113 <https://github.com/jrbourbeau/pycondor/pull/113>`_)
+
+
 Version 0.4.0 (2018-06-07)
 --------------------------
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -13,6 +13,7 @@ precision = 2
 
 [tool:pytest]
 addopts = -sv
+filterwarnings = always
 
 [flake8]
 exclude = __init__.py,__pycache__

--- a/setup.py
+++ b/setup.py
@@ -109,9 +109,7 @@ setup(
     extras_require=EXTRAS_REQUIRE,
     setup_requires=['setuptools>=38.6.0'],
     entry_points={
-        'console_scripts': ['dagman_progress=pycondor.cli:dagman_progress',
-                            'pycondor=pycondor.cli:cli',
-                            ],
+        'console_scripts': ['pycondor=pycondor.cli:cli'],
     },
     cmdclass={
         'upload': UploadCommand,


### PR DESCRIPTION
This PR removes the `dagman_progress` entry point from `setup.py` which was replaced with the new `monitor` command in the `cli` module. This should have been removed earlier, I must have overlooked it. 