### PR TITLE
Cleanup test warnings

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -24,6 +24,8 @@ Version 0.5.0 (TBD)
 
 - Removes outdated reference to ``dagman_progress`` in ``entry_points`` of
   ``setup.py``. (See `PR #113 <https://github.com/jrbourbeau/pycondor/pull/113>`_)
+- Resolves a ``ResourceWarning`` and ``DeprecationWarning`` raised while
+  running the tests. (See `PR #116 <https://github.com/jrbourbeau/pycondor/pull/116>`_)
 
 
 Version 0.4.0 (2018-06-07)

--- a/pycondor/cli.py
+++ b/pycondor/cli.py
@@ -180,7 +180,8 @@ def monitor(time_, length, prog_char, file):
         sys.stdout.flush()
         time.sleep(time_)
 
-    datetime_start = line_to_datetime(open(dag_out_file, 'r').readline())
+    with open(dag_out_file, 'r') as f:
+        datetime_start = line_to_datetime(f.readline())
     current_status = Status(*[0]*len(_states))
     try:
         for status, datetime_current in status_generator(dag_out_file):

--- a/pycondor/dagman.py
+++ b/pycondor/dagman.py
@@ -46,7 +46,7 @@ def _iter_job_args(job):
                          'to a Dagman'.format(job.name))
 
     if len(job.args) == 0:
-        raise StopIteration
+        return
     else:
         for idx, job_arg in enumerate(job):
             arg, name, retry = job_arg


### PR DESCRIPTION
This PR resolves a couple of warnings. Namely, a `ResourceWarning` due to a file not being closed in the cli `monitor` command, and a `DeprecationWarning` related to a generator raising a `StopIteration` instead of returning (see PEP 479). 