### PR TITLE
Fixes bytes issue in get_condor_version

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -26,6 +26,7 @@ Version 0.5.0 (TBD)
   ``setup.py``. (See `PR #113 <https://github.com/jrbourbeau/pycondor/pull/113>`_)
 - Resolves a ``ResourceWarning`` and ``DeprecationWarning`` raised while
   running the tests. (See `PR #116 <https://github.com/jrbourbeau/pycondor/pull/116>`_)
+- Properly handles bytes arrays in ``get_condor_version``. (See `PR #119 <https://github.com/jrbourbeau/pycondor/pull/119>`_)
 
 
 Version 0.4.0 (2018-06-07)

--- a/pycondor/tests/test_cli.py
+++ b/pycondor/tests/test_cli.py
@@ -89,10 +89,8 @@ def test_monitor_file_raises():
     runner = CliRunner()
     result = runner.invoke(monitor, [non_exist_file])
     assert result.exit_code == 2
-    expected_output = ('Usage: monitor [OPTIONS] FILE\n\nError: Invalid '
-                       'value for "file": Path "{}" does not '
-                       'exist.\n'.format(non_exist_file))
-    assert result.output.replace('\r', '') == expected_output
+    excerpt = 'Path "{}" does not exist'.format(non_exist_file)
+    assert excerpt in result.output.replace('\r', '')
 
 
 def test_submit_file_raises():
@@ -101,10 +99,8 @@ def test_submit_file_raises():
     runner = CliRunner()
     result = runner.invoke(submit, [non_exist_executable])
     assert result.exit_code == 2
-    expected_output = ('Usage: submit [OPTIONS] EXECUTABLE [ARGS]'
-                       '...\n\nError: Invalid value for "executable": Path '
-                       '"{}" does not exist.\n'.format(non_exist_executable))
-    assert result.output.replace('\r', '') == expected_output
+    excerpt = 'Path "{}" does not exist'.format(non_exist_executable)
+    assert excerpt in result.output.replace('\r', '')
 
 
 def test_submit_equality(tmpdir):

--- a/pycondor/tests/test_utils.py
+++ b/pycondor/tests/test_utils.py
@@ -4,7 +4,7 @@ import pytest
 import pycondor
 from pycondor.utils import (clear_pycondor_environment_variables, checkdir,
                             assert_command_exists, get_condor_version,
-                            split_command_string)
+                            parse_condor_version, split_command_string)
 
 
 def test_string_rep_None_fail():
@@ -78,6 +78,13 @@ def test_get_condor_version_raises():
         get_condor_version()
     error = 'Could not find HTCondor version.'
     assert error == str(excinfo.value)
+
+
+@pytest.mark.parametrize('info', ['$CondorVersion: 8.7.4 Oct 30 2017 BuildID: $',
+                                  b'$CondorVersion: 8.7.4 Oct 30 2017 BuildID: $'])
+def test_parse_condor_version(info):
+    version = parse_condor_version(info)
+    assert version == (8, 7, 4)
 
 
 def test_split_command_string():

--- a/setup.cfg
+++ b/setup.cfg
@@ -17,3 +17,4 @@ filterwarnings = always
 
 [flake8]
 exclude = __init__.py,__pycache__
+max-line-length = 100


### PR DESCRIPTION
This PR fixes a bug in `get_condor_version()` where `bytes` strings weren't handled properly.  

Closes #117