### PR TITLE
Add command line API docs

### DIFF
--- a/docs/cli.rst
+++ b/docs/cli.rst
@@ -2,9 +2,9 @@
 
 :github_url: https://github.com/jrbourbeau/pycondor
 
-**********************
-Command line interface
-**********************
+************
+Command line
+************
 
 -----------------
 Dagman Monitoring
@@ -64,3 +64,15 @@ the command line arguments to be passed to the executable. E.g.
     $ pycondor submit --request_memory 3GB my_script.py -- --script_option value
 
 See ``pycondor submit --help`` for a complete list of available command line options.
+
+---
+API
+---
+
+.. click:: pycondor.cli:monitor
+   :prog: pycondor monitor
+   :show-nested:
+
+.. click:: pycondor.cli:submit
+   :prog: pycondor submit
+   :show-nested:

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -38,6 +38,7 @@ extensions = ['sphinx.ext.autodoc',
               'sphinx.ext.autosummary',
               'sphinx.ext.githubpages',
               'numpydoc',
+              'sphinx_click.ext',
               ]
 
 # this is needed for some reason...

--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -2,6 +2,7 @@
 sphinx
 numpydoc
 sphinx_rtd_theme
+sphinx-click
 # Testing
 pytest
 pytest-cov


### PR DESCRIPTION
This PR adds API documentation for the PyCondor command line interface using the `sphinx-click` Sphinx extension