### PR TITLE
Use 'standard' file extensions for output files

### DIFF
--- a/pycondor/dagman.py
+++ b/pycondor/dagman.py
@@ -284,7 +284,7 @@ class Dagman(BaseNode):
             return self
 
         name = self._get_fancyname() if fancyname else self.name
-        submit_file = os.path.join(self.submit, '{}.submit'.format(name))
+        submit_file = os.path.join(self.submit, '{}.dag'.format(name))
         self.submit_file = submit_file
         self.submit_name = name
         checkdir(self.submit_file, makedirs)

--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -270,7 +270,7 @@ class Job(BaseNode):
 
         name = self._get_fancyname() if fancyname else self.name
         self.submit_name = name
-        submit_file = os.path.join(self.submit, '{}.submit'.format(name))
+        submit_file = os.path.join(self.submit, '{}.sub'.format(name))
         checkdir(submit_file, makedirs)
         # Add submit_file data member to job for later use
         self.submit_file = submit_file

--- a/pycondor/tests/test_cli.py
+++ b/pycondor/tests/test_cli.py
@@ -136,7 +136,7 @@ def test_submit_equality(tmpdir):
     assert result.exit_code == 0
 
     submit_file_2 = os.path.join(str(tmpdir),
-                                 '{}.submit'.format(name))
+                                 '{}.sub'.format(name))
     with open(submit_file_2, 'r') as f:
         submit_file_2 = f.readlines()
 
@@ -160,7 +160,7 @@ def test_submit_args(tmpdir):
     assert result.exit_code == 0
 
     submit_file = os.path.join(str(tmpdir),
-                               '{}.submit'.format(name))
+                               '{}.sub'.format(name))
     with open(submit_file, 'r') as f:
         submit_file_lines = f.read().splitlines()
 

--- a/pycondor/tests/test_dagman.py
+++ b/pycondor/tests/test_dagman.py
@@ -93,7 +93,7 @@ def test_get_subdag_string(tmpdir, dagman):
     submit_dir = os.path.dirname(dagman.submit_file)
     subdag_str = _get_subdag_string(dagman)
 
-    expected_str = 'SUBDAG EXTERNAL {} {}.submit'.format(
+    expected_str = 'SUBDAG EXTERNAL {} {}.dag'.format(
                         dagman.name,
                         os.path.join(submit_dir, dagman.name))
 

--- a/pycondor/tests/test_utils.py
+++ b/pycondor/tests/test_utils.py
@@ -90,7 +90,7 @@ def test_parse_condor_version(info):
 
 
 def test_split_command_string():
-    filename = os.path.join('condor', 'submit', 'job.submit')
+    filename = os.path.join('condor', 'submit', 'job.sub')
     command = "condor_submit -maxjobs 1000 -interactive {}".format(filename)
     expected = [
       'condor_submit',


### PR DESCRIPTION



<!-- Thank you for the pull request! -->

#### Reference Issue

Fixes #134



#### What does this pull request implement/fix? Explain your changes.

This PR patches the relevant class instance methods to use the following file extensions, rather than just `.submit` for everything:

- use `.dag` for dag files
- use `.sub` for submit files

#### Any other comments?
