### PR TITLE
Updated import for python3.8

### DIFF
--- a/pycondor/job.py
+++ b/pycondor/job.py
@@ -1,7 +1,11 @@
 
 import os
 import subprocess
-from collections import namedtuple, Iterable
+from collections import namedtuple
+try:
+    from collections.abc import Iterable
+except ImportError:  # python < 3.3
+    from collections import Iterable
 
 from .utils import (checkdir, string_rep, requires_command,
                     split_command_string, decode_string)


### PR DESCRIPTION

#### What does this pull request implement/fix? 

This PR fixes a `DeprecationWarning` on python3.7 warning of code that will fail on python>=3.8.

#### Any other comments?
This is backwards compatible with python<3.3.